### PR TITLE
RANCHER-50 increase timeouts in okapi-values annotations

### DIFF
--- a/okapi/values.yaml
+++ b/okapi/values.yaml
@@ -46,9 +46,9 @@ ingress:
   enabled: false
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
   hosts:
     - host:
       paths: []


### PR DESCRIPTION
Increased timeout values in Okapi helm in annotations from 900 to 1800 seconds