### PR TITLE
RANCHER-182: Remove signing key from mod-authtoken chart

### DIFF
--- a/mod-authtoken/values.yaml
+++ b/mod-authtoken/values.yaml
@@ -80,7 +80,7 @@ tolerations: []
 affinity: {}
 
 # Folio specific
-javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dcache.permissions=true -Djwt.signing.key=123456789
+javaOptions: -XX:MaxRAMPercentage=85.0 -XX:+UseG1GC -Dcache.permissions=true
 dbMaxPoolSize: 5
 
 postJob:


### PR DESCRIPTION
The key isn't required. When including it in the chart like this there are some dangers:
* Someone using the chart may not notice the key and override it as they should with a secret.
* If it isn't overridden then the signing key is out in the open.

mod-authtoken [doesn't require](https://github.com/folio-org/mod-authtoken/blob/46e9fe138b51c38b010c900cf31a3a60ce042228/src/main/java/org/folio/auth/authtokenmodule/TokenCreator.java#L35) that this key be set. If it isn't set, a much more desirable thing happens: a random key is used.

When a random key is used, restarting mod-authtoken causes all tokens to be invalidated, which, absent token revocation (which FOLIO doesn't yet have), is a good thing.
