### PR TITLE
RANCHER-460: Upgrade create-tenant/Dockerfile fixing CVE-2022-37434

### DIFF
--- a/docker/create-tenant/Dockerfile
+++ b/docker/create-tenant/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.11
+FROM alpine:3.16
 
 #Prerequisites
-RUN apk add --no-cache curl jq bash && rm -rf /var/cache/apk/*
+RUN apk upgrade \
+ && apk add curl jq bash \
+ && rm -rf /var/cache/apk/*
 
 #Create folders in container
 RUN mkdir -p /usr/local/bin/folio/install


### PR DESCRIPTION
Upgrade https://github.com/folio-org/folio-helm/blob/master/docker/create-tenant/Dockerfile by bumping Alpine from 3.11 (end of support since 2021-11-01: https://alpinelinux.org/releases/ ) to 3.16 and using apk upgrade to bump zlib from 1.2.11-r3 to zlib/zlib@1.2.11-r4 fixing https://nvd.nist.gov/vuln/detail/CVE-2022-37434